### PR TITLE
Add repository information an keywords

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
   "author": "Rafal Stozek <rafal.stozek@gmail.com>",
   "repository": {
     "type": "git",
-    "url": "https://github.com/artificialio/sane"
+    "url": "https://github.com/rafales/broccoli-webpack-fast"
   },
   "bugs": {
-    "url": "https://github.com/artificialio/sane/issues"
+    "url": "https://github.com/rafales/broccoli-webpack-fast/issues"
   },
     "keywords": [
     "broccoli",

--- a/package.json
+++ b/package.json
@@ -1,12 +1,25 @@
 {
   "name": "broccoli-webpack-fast",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Webpack plugin for Broccoli with fast rebuilds.",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "Rafal Stozek <rafal.stozek@gmail.com>",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/artificialio/sane"
+  },
+  "bugs": {
+    "url": "https://github.com/artificialio/sane/issues"
+  },
+    "keywords": [
+    "broccoli",
+    "broccoli-plugin",
+    "webpack",
+    "bundle"
+  ],
   "license": "MIT",
   "dependencies": {
     "broccoli": "^0.13.3",


### PR DESCRIPTION
This just makes the repository and plugin more discoverable (by linking back to github and being marked as an official broccoli plugin)
